### PR TITLE
fix: support for typescript 4.7+ exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "module": "dist/stadiamaps-api.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/stadiamaps-api.mjs",
       "require": "./dist/stadiamaps-api.umd.js"
     }


### PR DESCRIPTION
See
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing.

Add proper export of types for TS 4.7-5.

I ran into an issue importing the package TS 5 and after some digging was able to correct it locally by updating package.json per the docs.

Kept the existing "types" definition on package.json for backwards compatibility.